### PR TITLE
Add model output class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: quality style
 
-check_dirs := ensemble_transformers
+check_dirs := ensemble_transformers tests
 
 quality: # Check that source code meets quality standards
 	black --check $(check_dirs)

--- a/ensemble_transformers/base.py
+++ b/ensemble_transformers/base.py
@@ -47,7 +47,7 @@ class EnsembleBaseModel(PreTrainedModel):
         return cls(config, **kwargs)
 
     def forward(
-        self, inputs, preprocessor_kwargs: dict, return_all_outputs: bool, main_device: Union[str, torch.device]
+        self, inputs, preprocessor_kwargs: dict, mean_pool: bool, main_device: Union[str, torch.device]
     ) -> EnsembleModelOutput:
         outputs = []
         for i, (model, preprocessor) in enumerate(zip(self.models, self.preprocessors)):
@@ -55,7 +55,7 @@ class EnsembleBaseModel(PreTrainedModel):
             output = model(**preprocessed)
             outputs.append(output)
         ensemble_output = EnsembleModelOutput(outputs)
-        if return_all_outputs:
+        if not mean_pool:
             return ensemble_output
         ensemble_output.stack(self.config.weights, main_device)
         return ensemble_output

--- a/ensemble_transformers/base.py
+++ b/ensemble_transformers/base.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from typing import List, Optional, Union
 
 import torch
@@ -6,6 +5,7 @@ from torch import nn
 from transformers import PreTrainedModel
 
 from .config import EnsembleConfig
+from .output import EnsembleModelOutput
 
 
 class EnsembleBaseModel(PreTrainedModel):
@@ -46,6 +46,16 @@ class EnsembleBaseModel(PreTrainedModel):
         config = EnsembleConfig(auto_class, model_names, weights=weights)
         return cls(config, **kwargs)
 
-    @abstractmethod
-    def forward(self, *args, **kwargs):
-        pass
+    def forward(
+        self, inputs, preprocessor_kwargs: dict, return_all_outputs: bool, main_device: Union[str, torch.device]
+    ) -> EnsembleModelOutput:
+        outputs = []
+        for i, (model, preprocessor) in enumerate(zip(self.models, self.preprocessors)):
+            preprocessed = preprocessor(inputs, **preprocessor_kwargs).to(self.devices[i])
+            output = model(**preprocessed)
+            outputs.append(output)
+        ensemble_output = EnsembleModelOutput(outputs)
+        if return_all_outputs:
+            return ensemble_output
+        ensemble_output.stack(self.config.weights, main_device)
+        return ensemble_output

--- a/ensemble_transformers/config.py
+++ b/ensemble_transformers/config.py
@@ -50,7 +50,11 @@ class EnsembleConfig(PretrainedConfig):
                     f"but got {len(weights)} elements instead."
                 )
             weight_sum = sum(weights)
-            self.weights = [weight / weight_sum for weight in weights]
+            if weight_sum != 1:
+                warnings.warn("Normalizing `weights` to sum to 1.")
+                self.weights = [weight / weight_sum for weight in weights]
+            else:
+                self.weights = weights
         else:
             self.weights = [1 / num_models for _ in range(num_models)]
         self.model_names = model_names

--- a/ensemble_transformers/ensemble.py
+++ b/ensemble_transformers/ensemble.py
@@ -12,10 +12,10 @@ class EnsembleModelForSequenceClassification(EnsembleBaseModel):
         self,
         text: List[str],
         preprocessor_kwargs: dict = {"return_tensors": "pt", "padding": True},
-        return_all_outputs: bool = True,
+        mean_pool: bool = False,
         main_device: Union[str, torch.device] = "cpu",
     ):
-        return super().forward(text, preprocessor_kwargs, return_all_outputs, main_device)
+        return super().forward(text, preprocessor_kwargs, mean_pool, main_device)
 
 
 class EnsembleModelForImageClassification(EnsembleBaseModel):
@@ -23,10 +23,10 @@ class EnsembleModelForImageClassification(EnsembleBaseModel):
         self,
         images: List[Image],
         preprocessor_kwargs: dict = {"return_tensors": "pt"},
-        return_all_outputs: bool = True,
+        mean_pool: bool = False,
         main_device: Union[str, torch.device] = "cpu",
     ):
-        return super().forward(images, preprocessor_kwargs, return_all_outputs, main_device)
+        return super().forward(images, preprocessor_kwargs, mean_pool, main_device)
 
 
 class EnsembleModelForAudioClassification(EnsembleBaseModel):
@@ -34,7 +34,7 @@ class EnsembleModelForAudioClassification(EnsembleBaseModel):
         self,
         audio: np.ndarray,
         preprocessor_kwargs: dict = {"return_tensors": "pt", "sampling_rate": None, "padding": "longest"},
-        return_all_outputs: bool = True,
+        mean_pool: bool = False,
         main_device: Union[str, torch.device] = "cpu",
     ):
-        return super().forward(audio, preprocessor_kwargs, return_all_outputs, main_device)
+        return super().forward(audio, preprocessor_kwargs, mean_pool, main_device)

--- a/ensemble_transformers/ensemble.py
+++ b/ensemble_transformers/ensemble.py
@@ -11,57 +11,30 @@ class EnsembleModelForSequenceClassification(EnsembleBaseModel):
     def forward(
         self,
         text: List[str],
-        main_device: Union[str, torch.device] = "cpu",
-        return_all_outputs: bool = False,
         preprocessor_kwargs: dict = {"return_tensors": "pt", "padding": True},
+        return_all_outputs: bool = True,
+        main_device: Union[str, torch.device] = "cpu",
     ):
-        outputs = []
-        for i, (model, preprocessor) in enumerate(zip(self.models, self.preprocessors)):
-            inputs = preprocessor(text, **preprocessor_kwargs).to(self.devices[i])
-            output = model(**inputs)
-            outputs.append(output)
-        if return_all_outputs:
-            return outputs
-        return torch.stack(
-            [weight * output.logits.to(main_device) for weight, output in zip(self.config.weights, outputs)]
-        ).sum(dim=0)
+        return super().forward(text, preprocessor_kwargs, return_all_outputs, main_device)
 
 
 class EnsembleModelForImageClassification(EnsembleBaseModel):
     def forward(
         self,
         images: List[Image],
-        main_device: Union[str, torch.device] = "cpu",
-        return_all_outputs: bool = False,
         preprocessor_kwargs: dict = {"return_tensors": "pt"},
+        return_all_outputs: bool = True,
+        main_device: Union[str, torch.device] = "cpu",
     ):
-        outputs = []
-        for i, (model, preprocessor) in enumerate(zip(self.models, self.preprocessors)):
-            inputs = preprocessor(images, **preprocessor_kwargs).to(self.devices[i])
-            output = model(**inputs)
-            outputs.append(output)
-        if return_all_outputs:
-            return outputs
-        return torch.stack(
-            [weight * output.logits.to(main_device) for weight, output in zip(self.config.weights, outputs)]
-        ).sum(dim=0)
+        return super().forward(images, preprocessor_kwargs, return_all_outputs, main_device)
 
 
 class EnsembleModelForAudioClassification(EnsembleBaseModel):
     def forward(
         self,
         audio: np.ndarray,
-        main_device: Union[str, torch.device] = "cpu",
-        return_all_outputs: bool = False,
         preprocessor_kwargs: dict = {"return_tensors": "pt", "sampling_rate": None, "padding": "longest"},
+        return_all_outputs: bool = True,
+        main_device: Union[str, torch.device] = "cpu",
     ):
-        outputs = []
-        for i, (model, preprocessor) in enumerate(zip(self.models, self.preprocessors)):
-            inputs = preprocessor(audio, **preprocessor_kwargs).to(self.devices[i])
-            output = model(**inputs)
-            outputs.append(output)
-        if return_all_outputs:
-            return outputs
-        return torch.stack(
-            [weight * output.logits.to(main_device) for weight, output in zip(self.config.weights, outputs)]
-        ).sum(dim=0)
+        return super().forward(audio, preprocessor_kwargs, return_all_outputs, main_device)

--- a/ensemble_transformers/output.py
+++ b/ensemble_transformers/output.py
@@ -29,8 +29,9 @@ class EnsembleModelOutput:
             )
 
     def __repr__(self) -> str:
-        result = []
+        result = ["EnsembleModelOutput("]
         for common_key in self.common_keys:
             value = getattr(self, common_key)
-            result.append(f"{common_key}: {repr(value)}")
+            result.append(f"\t{common_key}: {repr(value)},")
+        result.append(")")
         return "\n".join(result)

--- a/ensemble_transformers/output.py
+++ b/ensemble_transformers/output.py
@@ -1,0 +1,36 @@
+from typing import List, Union
+
+import torch
+
+
+class EnsembleModelOutput:
+    def __init__(self, outputs):
+        self.outputs = outputs
+        self.common_keys = None
+        for output in outputs:
+            if self.common_keys is None:
+                self.common_keys = output.keys()
+            else:
+                self.common_keys &= output.keys()
+        for common_key in self.common_keys:
+            setattr(self, common_key, [getattr(output, common_key) for output in outputs])
+
+    def stack(self, weights: List[float], main_device: Union[str, torch.device]) -> None:
+        for common_key in self.common_keys:
+            setattr(
+                self,
+                common_key,
+                torch.stack(
+                    [
+                        weight * getattr(output, common_key).to(main_device)
+                        for weight, output in zip(weights, self.outputs)
+                    ]
+                ).sum(dim=0),
+            )
+
+    def __repr__(self) -> str:
+        result = []
+        for common_key in self.common_keys:
+            value = getattr(self, common_key)
+            result.append(f"{common_key}: {repr(value)}")
+        return "\n".join(result)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 black
 flake8
 isort
+pytest

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,16 +3,13 @@ import torch
 from ensemble_transformers import EnsembleModelForSequenceClassification
 
 
-class TestTextEnsemble:
-    @classmethod
-    def setup_class(cls):
-        cls.model_names = ["distilroberta-base", "xlnet-base-cased", "bert-base-uncased"]
-        cls.ensemble = EnsembleModelForSequenceClassification.from_multiple_pretrained(*cls.model_names)
-
-    def test_ensemble(self):
-        batch = ["This is a test sentence", "This is another test sentence."]
-        with torch.no_grad():
-            output = self.ensemble(batch)
-        assert len(output.logits) == len(self.model_names)
-        output.stack(self.ensemble.config.weights, "cpu")
-        assert len(output.logits) == 1
+def test_ensemble():
+    model_names = ["hf-internal-testing/tiny-bert", "hf-internal-testing/tiny-albert", "hf-internal-testing/tiny-electra", "hf-internal-testing/tiny-xlm-roberta"]
+    ensemble = EnsembleModelForSequenceClassification.from_multiple_pretrained(*model_names)
+    batch = ["This is a test sentence", "This is another test sentence."]
+    with torch.no_grad():
+        output = ensemble(batch)
+    assert len(output.logits) == len(model_names)
+    shape = output.logits[0].shape
+    output.stack(ensemble.config.weights, "cpu")
+    assert output.logits.shape == shape

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,18 @@
+import torch
+
+from ensemble_transformers import EnsembleModelForSequenceClassification
+
+
+class TestTextEnsemble:
+    @classmethod
+    def setup_class(cls):
+        cls.model_names = ["distilroberta-base", "xlnet-base-cased", "bert-base-uncased"]
+        cls.ensemble = EnsembleModelForSequenceClassification.from_multiple_pretrained(*cls.model_names)
+
+    def test_ensemble(self):
+        batch = ["This is a test sentence", "This is another test sentence."]
+        with torch.no_grad():
+            output = self.ensemble(batch)
+        assert len(output.logits) == len(self.model_names)
+        output.stack(self.ensemble.config.weights, "cpu")
+        assert len(output.logits) == 1

--- a/tests/test_invalid.py
+++ b/tests/test_invalid.py
@@ -5,17 +5,22 @@ from ensemble_transformers.base import EnsembleBaseModel
 
 
 def test_modality():
-    pass
+    with pytest.raises(ValueError):
+        EnsembleModelForSequenceClassification.from_multiple_pretrained(
+            "hf-internal-testing/tiny-random-distilbert",
+            "hf-internal-testing/tiny-random-vit",
+        )
 
 
 def test_to_multiple():
     ensemble = EnsembleModelForSequenceClassification.from_multiple_pretrained(
-        "distilroberta-base", "bert-base-uncased"
+        "hf-internal-testing/tiny-bert",
+        "hf-internal-testing/tiny-random-distilbert",
     )
     with pytest.raises(ValueError):
         ensemble.to_multiple(["cpu"])
 
 
 def test_base_init():
-    with pytest.raises(ValueError):
-        EnsembleBaseModel.from_multiple_pretrained("bert-base-uncased")
+    with pytest.raises(RuntimeError):
+        EnsembleBaseModel.from_multiple_pretrained("hf-internal-testing/tiny-bert")

--- a/tests/test_invalid.py
+++ b/tests/test_invalid.py
@@ -1,0 +1,21 @@
+import pytest
+
+from ensemble_transformers import EnsembleModelForSequenceClassification
+from ensemble_transformers.base import EnsembleBaseModel
+
+
+def test_modality():
+    pass
+
+
+def test_to_multiple():
+    ensemble = EnsembleModelForSequenceClassification.from_multiple_pretrained(
+        "distilroberta-base", "bert-base-uncased"
+    )
+    with pytest.raises(ValueError):
+        ensemble.to_multiple(["cpu"])
+
+
+def test_base_init():
+    with pytest.raises(ValueError):
+        EnsembleBaseModel.from_multiple_pretrained("bert-base-uncased")


### PR DESCRIPTION
**Context**
1. Previously, each ensemble class had its own forward method. However, this was duplicated code. 
2. Like HF's transformers, it makes a lot more sense to create an interface around an output class, which can hold different fields depending on the modality.
3. We'd also like to have at least a minimum testing suite. 

**Solution**
1. Factor out the duplicated code into the base class.
2. Introduce an `EnsembleModelOutput` class which can hold varying attributes depending on the modality. Moreover, this class can also handle mean-pooling logic.
3. Add basic tests for modality checks, ensemble coherence, and device movement.